### PR TITLE
Remove the hyphen in PR major versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The general idea is to generate a unique version string from the job context tha
 | ------------ | ------- | ------- |
 | Git tag      | \<tagname\> | v1.3.2
 | Branch       | \<branchname\>-\<runnumber\>-\<sha\>  | main-9-f025368a |
-| Pull request | pr-\<prnumber\>-\<runnumber\>-\<sha\> | pr-9-1-89d735ed |
+| Pull request | pr\<prnumber\>-\<runnumber\>-\<sha\> | pr9-1-89d735ed |
 
 Tags are assumed to already satisfy these goals and are taken as-is. For other cases, the first part (branch name or PR number) tells whether two version can be compared, the second part (build number) allows to quickly tell versions apart, and the commit hash uniquely identifies the revision of the source that was build.
 
@@ -31,7 +31,7 @@ Tags are assumed to already satisfy these goals and are taken as-is. For other c
 | refs/tags/1.2.3.4| 9| a52f| 1.2.3.4| 1.2.3.4| 1| 2| 3.4|
 | refs/heads/main| 9| a52f| main-9-a52f| main-9-a52f| main| 9| a52f|
 | refs/heads/stable| 9| a52f| stable-9-a52f| stable-9-a52f| stable| 9| a52f|
-| refs/pull/1/merge| 9| a52f| pr-1-9-a52f| pr-1-9-a52f| pr-1| 9| a52f|
+| refs/pull/1/merge| 9| a52f| pr1-9-a52f| pr1-9-a52f| pr1| 9| a52f|
 
 ## Example Usage
 ```

--- a/test/testVersion.js
+++ b/test/testVersion.js
@@ -4,8 +4,8 @@ let version = require('../version');
 
 let testData = [
     ['refs/heads/main', '1', 'abcd', 'main-1-abcd', 'main', '1', 'abcd'],
-    ['refs/pull/1/merge', '2', 'abcd', 'pr-1-2-abcd', 'pr-1', '2', 'abcd'],
-    ['refs/pull/1/base', '2', 'abcd', 'pr-1-2-abcd', 'pr-1', '2', 'abcd'],
+    ['refs/pull/1/merge', '2', 'abcd', 'pr1-2-abcd', 'pr1', '2', 'abcd'],
+    ['refs/pull/1/base', '2', 'abcd', 'pr1-2-abcd', 'pr1', '2', 'abcd'],
     ['refs/tags/v1', '2', 'abcd', 'v1', '1', '', ''],
     ['refs/tags/1.0', '2', 'abcd', '1.0', '1', '0', ''],
     ['refs/tags/1.0.0', '2', 'abcd', '1.0.0', '1', '0', '0'],
@@ -20,7 +20,7 @@ let testDataWithoutV = [
     // do nothing for branches
     ['refs/heads/main', '1', 'abcd', 'main-1-abcd'],
     ['refs/heads/v100', '1', 'abcd', 'v100-1-abcd'],
-    ['refs/pull/1/merge', '2', 'abcd', 'pr-1-2-abcd'],
+    ['refs/pull/1/merge', '2', 'abcd', 'pr1-2-abcd'],
 
     // strip leading v from version numbers
     ['refs/tags/1.0.0', '2', 'abcd', '1.0.0'],

--- a/version.js
+++ b/version.js
@@ -20,7 +20,7 @@ function fromTag(tag) {
 function fromRefRunSha(ref, run, sha) {
     sha = sha.substr(0, 8);
     if (ref.startsWith('refs/pull/')) {
-        ref = ref.replace(/^refs\/pull\/(\d+)\/.*/, 'pr-$1');
+        ref = ref.replace(/^refs\/pull\/(\d+)\/.*/, 'pr$1');
     } else {
         ref = ref.replace(/^refs\/heads\//, '');
     }


### PR DESCRIPTION
The hyphen can be problematic, e.g. when using the version for an RPM.